### PR TITLE
SP2-100-Add unit tests for DataPoint class

### DIFF
--- a/Heatington.Tests/Models/DataPointTests.cs
+++ b/Heatington.Tests/Models/DataPointTests.cs
@@ -1,0 +1,54 @@
+using Heatington.Models;
+using System.Globalization;
+using Xunit.Abstractions;
+
+namespace Heatington.Tests.Models
+{
+    public class DataPointTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public DataPointTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void Constructor_ShouldParse_ValidArguments()
+        {
+            const string startTime = "1/1/21 12:00";
+            const string endTime = "1/1/21 13:00";
+            const string heatDemand = "1.23";
+            const string electricityPrice = "4.56";
+
+            var dataPoint = new DataPoint(startTime, endTime, heatDemand, electricityPrice);
+
+            _output.WriteLine(
+                $"StartTime: Expected {startTime}, got {dataPoint.StartTime.ToString("M/d/yy H:mm", CultureInfo.InvariantCulture)}");
+            _output.WriteLine(
+                $"EndTime: Expected {endTime}, got {dataPoint.EndTime.ToString("M/d/yy H:mm", CultureInfo.InvariantCulture)}");
+            _output.WriteLine(
+                $"HeatDemand: Expected {heatDemand}, got {dataPoint.HeatDemand.ToString(CultureInfo.InvariantCulture)}");
+            _output.WriteLine(
+                $"ElectricityPrice: Expected {electricityPrice}, got {dataPoint.ElectricityPrice.ToString(CultureInfo.InvariantCulture)}");
+
+            Assert.Equal(DateTime.ParseExact(startTime, "M/d/yy H:mm", CultureInfo.InvariantCulture),
+                dataPoint.StartTime);
+            Assert.Equal(DateTime.ParseExact(endTime, "M/d/yy H:mm", CultureInfo.InvariantCulture), dataPoint.EndTime);
+            Assert.Equal(double.Parse(heatDemand, CultureInfo.InvariantCulture), dataPoint.HeatDemand);
+            Assert.Equal(double.Parse(electricityPrice, CultureInfo.InvariantCulture), dataPoint.ElectricityPrice);
+        }
+
+        [Fact]
+        public void Constructor_ShouldThrowFormatException_ForInvalidArguments()
+        {
+            const string invalidTime = "invalid time";
+            const string invalidDouble = "invalid double";
+
+            Assert.Throws<FormatException>(() => new DataPoint(invalidTime, "1/1/21 13:00", "1.23", "4.56"));
+            Assert.Throws<FormatException>(() => new DataPoint("1/1/21 12:00", invalidTime, "1.23", "4.56"));
+            Assert.Throws<FormatException>(() => new DataPoint("1/1/21 12:00", "1/1/21 13:00", invalidDouble, "4.56"));
+            Assert.Throws<FormatException>(() => new DataPoint("1/1/21 12:00", "1/1/21 13:00", "1.23", invalidDouble));
+        }
+    }
+}

--- a/Heatington.Tests/Models/DataPointTests.md
+++ b/Heatington.Tests/Models/DataPointTests.md
@@ -1,0 +1,35 @@
+# `DataPoint` Unit Tests
+
+This document describes the unit tests for the `DataPoint` class.
+
+## Test Class
+
+The `DataPointTests` class in the `Heatington.Tests.Models` namespace contains the unit tests for the `DataPoint` constructor.
+
+## Test Methods
+
+### `Constructor_ShouldParse_ValidArguments`
+
+This test method verifies that the `DataPoint` constructor correctly parses strings to the appropriate data types (e.g., `DateTime` and `double`).
+
+It provides a set of valid arguments to the `DataPoint` constructor, and compares the properties of the created object to the expected values. The test will pass if all properties match the expected values.
+
+Useful output indicating the expected and gotten values for every property are also provided during test execution.
+
+### `Constructor_ShouldThrowFormatException_ForInvalidArguments`
+
+This test method verifies that the `DataPoint` constructor throws a FormatException when an argument cannot be parsed to the correct data type.
+
+It provides sets of invalid arguments to the `DataPoint` constructor in various combinations. The test will pass if a `FormatException` is thrown in each case.
+
+## Setup and using `ITestOutputHelper`
+
+An `ITestOutputHelper` is being used in this class to help with producing diagnostic output. This can be especially useful when trying to debug failures in the tests.
+
+Its output will be present in the test runner's output window whenever the unit test is run. This output will contain statements showing the expected and actual values for each property during the execution of `Constructor_ShouldParse_ValidArguments`.
+
+## Running the Tests
+
+Run these tests by using your preferred .NET test runner and navigating to the `DataPointTests` class.
+
+These tests ensure that the `DataPoint` class and its constructor are working as expected under different circumstances.


### PR DESCRIPTION
New test file, DataPointTests.cs, has been created for the DataPoint class. It contains two test methods to check the behaviuor of the DataPoint constructor - one verifies correct parsing of valid arguments and the other checks that a FormatException is thrown when arguments can't be parsed to the correct data type. A markdown file with details and usage instructions for these unit tests was also added.