### PR TITLE
SP2-99-create unit test for source data manager cs

### DIFF
--- a/Heatington.Tests/SourceDataManager/SourceDataManagerTests.cs
+++ b/Heatington.Tests/SourceDataManager/SourceDataManagerTests.cs
@@ -1,0 +1,81 @@
+using Heatington.Data;
+using Heatington.Models;
+
+
+// TODO: No test for ConvertApiToCsv yet and LogTimesSeriesData won't be tested because the method will be removed after Implementation of GUI
+
+namespace Heatington.Tests.SourceDataManager
+{
+    public class SourceDataManagerTest
+    {
+        private readonly FakeDataSource _fakeDataSource;
+        private readonly Heatington.SourceDataManager.SourceDataManager _sourceDataManager;
+
+        public SourceDataManagerTest()
+        {
+            _fakeDataSource = new FakeDataSource();
+            _sourceDataManager = new Heatington.SourceDataManager.SourceDataManager(_fakeDataSource, "test-path");
+        }
+
+        [Theory]
+        [InlineData("2/8/23 0:00", "2/8/23 1:00", "6.62", "1190.94")]
+
+        [InlineData("2/8/23 0:00", "2/8/23 1:00", "6.62", "1190.94",
+            "2/8/23 1:00", "2/8/23 2:00", "6.65", "1190.99",
+            "2/8/23 2:00", "2/8/23 3:00", "6.69", "1190.97")]
+
+        [InlineData("2/8/23 0:00", "2/8/23 1:00", "6.62", "1190.94",
+            "2/8/23 1:00", "2/8/23 2:00", "6.65", "1190.99",
+            "2/8/23 2:00", "2/8/23 3:00", "6.69", "1190.97",
+            "2/8/23 3:00", "2/8/23 4:00", "6.71", "1190.99",
+            "2/8/23 4:00", "2/8/23 5:00", "6.73", "1191.01")]
+
+        [InlineData("2/8/23 0:00", "2/8/23 1:00", "6.62", "1190.94",
+            "2/8/23 1:00", "2/8/23 2:00", "6.65", "1190.99",
+            "2/8/23 2:00", "2/8/23 3:00", "6.69", "1190.97",
+            "2/8/23 3:00", "2/8/23 4:00", "6.71", "1190.99",
+            "2/8/23 4:00", "2/8/23 5:00", "6.73", "1191.01",
+            "2/8/23 5:00", "2/8/23 6:00", "6.75", "1191.03",
+            "2/8/23 6:00", "2/8/23 7:00", "6.77", "1191.05")]
+
+        [InlineData("2/8/23 0:00", "2/8/23 1:00", "6.62", "1190.94",
+            "2/8/23 1:00", "2/8/23 2:00", "6.65", "1190.99",
+            "2/8/23 2:00", "2/8/23 3:00", "6.69", "1190.97",
+            "2/8/23 3:00", "2/8/23 4:00", "6.71", "1190.99",
+            "2/8/23 4:00", "2/8/23 5:00", "6.73", "1191.01",
+            "2/8/23 5:00", "2/8/23 6:00", "6.75", "1191.03",
+            "2/8/23 6:00", "2/8/23 7:00", "6.77", "1191.05",
+            "2/8/23 7:00", "2/8/23 8:00", "6.79", "1191.07",
+            "2/8/23 8:00", "2/8/23 9:00", "6.81", "1191.09")]
+        public async Task FetchTimeSeriesDataAsync_ShouldFetchDataSuccessfully(params string[] data)
+        {
+            // Arrange
+            _fakeDataSource.Data = new List<DataPoint>();
+            for (int i = 0; i < data.Length; i += 4)
+            {
+                _fakeDataSource.Data.Add(new DataPoint(data[i], data[i + 1], data[i + 2], data[i + 3]));
+            }
+
+            // Act
+            await _sourceDataManager.FetchTimeSeriesDataAsync();
+
+            // Assert
+            Assert.Equal(_fakeDataSource.Data.Count, _sourceDataManager.TimeSeriesData?.Count);
+        }
+    }
+
+    public class FakeDataSource : IDataSource
+    {
+        public List<DataPoint>? Data { get; set; }
+
+        public async Task<List<DataPoint>?> GetDataAsync(string filePath)
+        {
+            return await Task.FromResult(Data);
+        }
+
+        public void SaveData(List<DataPoint> data, string filePath)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Heatington.Tests/SourceDataManager/SourceDataManagerTests.md
+++ b/Heatington.Tests/SourceDataManager/SourceDataManagerTests.md
@@ -1,0 +1,43 @@
+# SourceDataManager Unit Test
+
+This document provides an overview of a unit test for `SourceDataManager`.
+
+## Source DataManager Test Class
+
+`SourceDataManagerTest` is a class that contains unit tests for the `SourceDataManager` class. The class includes a setup to establish and initialize the dependencies for the test.
+
+```csharp
+private readonly FakeDataSource _fakeDataSource;
+private readonly Heatington.SourceDataManager.SourceDataManager _sourceDataManager;
+```
+
+`_fakeDataSource` is an instance of `FakeDataSource`, a stub class that mimics the behavior of a real-world data storage.
+`_sourceDataManager` is the class instance we are testing, `SourceDataManager`.
+
+## Test Method: FetchTimeSeriesDataAsync_ShouldFetchDataSuccessfully
+
+This method tests the behavior of the `FetchTimeSeriesDataAsync` method under different scenarios. To facilitate this, we are using the `Theory` attribute along with multiple `InlineData` attributes.
+
+```csharp
+[Theory] ...
+public async Task FetchTimeSeriesDataAsync_ShouldFetchDataSuccessfully(params string[] data)
+{ ...
+```
+
+This means that this test method will be run multiple times, once for each `InlineData` attribute. The parameters for each `InlineData` attribute are mapped to the `data` array.
+
+Inside the test method:
+- In the Arrange step, an array of data points (timestamps and the corresponding heat and electricity readings) are created and added to `_fakeDataSource.Data`,
+- The Act step calls the `FetchTimeSeriesDataAsync` method, and
+- The Assert step asserts that the data fetched from the `FetchTimeSeriesDataAsync` method and the `_fakeDataSource.Data` counts are equal, confirming the fetch function's correct functioning.
+
+## Fake Data Source
+
+The `FakeDataSource` class is used to simulate the `IDataSource` interface's behaviors. This "mock" class allows for testing the `SourceDataManager` in isolation, without requiring any actual data source.
+
+The `GetDataAsync` method in `FakeDataSource` returns the data objects set in the test method. The `SaveData` method is not used in these tests and therefore throws a `NotImplementedException` when called. This class enables a controlled environment that makes the tests more predictable and easier to debug.
+
+## Notes
+
+The team has decided against using a mocking framework for this project, opting instead for manual stubs and fakes.
+This decision was made to keep the project lightweight and avoid introducing unnecessary dependencies.


### PR DESCRIPTION
The commit includes the creation of unit tests for the SourceDataManager class in the Heatington.Tests project. These tests focus primarily on the functionality of the FetchTimeSeriesDataAsync method, using various input data scenarios. In addition, a FakeDataSource class is used to simulate real-world data storage, helping to test the SourceDataManager in isolation.

Should be quite ok. I still prefer using Moq instead of creating my own fakes and stubs.